### PR TITLE
R1 summary

### DIFF
--- a/python/rss-to-markdown.py
+++ b/python/rss-to-markdown.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+RSS to Markdown converter for AI research papers feed with LLM summarization
+"""
+import requests
+from datetime import datetime
+import xml.etree.ElementTree as ET
+from groq import Groq
+
+
+def fetch_rss(url):
+    """Fetch RSS feed content from URL"""
+    response = requests.get(url)
+    response.raise_for_status()  # Raise exception for HTTP errors
+    return response.text
+
+
+def parse_rss_to_markdown(xml_content):
+    """Parse RSS XML content and convert to markdown format"""
+    root = ET.fromstring(xml_content)
+    
+    # Extract channel info
+    channel = root.find('channel')
+    title = channel.find('title').text
+    description = channel.find('description').text
+    last_build_date = channel.find('lastBuildDate').text
+    
+    # Format date
+    try:
+        parsed_date = datetime.strptime(last_build_date, '%a, %d %b %Y %H:%M:%S %z')
+        formatted_date = parsed_date.strftime('%Y-%m-%d')
+    except ValueError:
+        formatted_date = last_build_date  # Fallback to original format
+    
+    # Create markdown header
+    markdown = f"# {title}\n\n"
+    markdown += f"*{description}*\n\n"
+    markdown += f"*Last updated: {formatted_date}*\n\n"
+    markdown += "---\n\n"
+    
+    # Process each item
+    for item in channel.findall('item'):
+        item_title = item.find('title').text.replace('\n', ' ').strip()
+        item_link = item.find('link').text
+        item_desc = item.find('description').text
+        
+        markdown += f"## [{item_title}]({item_link})\n\n"
+        markdown += f"{item_desc}\n\n"
+        markdown += "---\n\n"
+    
+    return markdown
+
+
+def summarize_with_groq(markdown_content):
+    """Summarize the markdown content using Groq API"""
+    client = Groq(api_key="")
+    completion = client.chat.completions.create(
+        model="deepseek-r1-distill-llama-70b",
+        messages=[
+            {
+                "role": "user",
+                "content": """Create a brief morning briefing on these AI research papers, written in a conversational style for busy professionals. Focus on what's new and what it means for businesses and society.
+
+Format:
+1. Morning Headline (1 sentence)
+2. What's New (2-3 sentences, written like you're explaining it to a friend over coffee, with citations to papers as [Paper Name](link))
+   • Cover all papers in a natural, flowing narrative
+   • Group related papers together
+   • Include key metrics and outcomes
+   • Keep the tone light and engaging
+
+Keep it under 200 words. Focus on outcomes and implications, not technical details. Write like you're explaining it to a friend over coffee.
+
+Below are the paper abstracts and information in markdown format:
+
+""" + markdown_content
+            }
+        ],
+        temperature=0.6,
+        max_completion_tokens=4096,
+        top_p=0.95,
+        stream=False,
+        stop=None,
+    )
+    
+    # Extract only the content after <think> tags
+    response = completion.choices[0].message.content
+    if "<think>" in response:
+        response = response.split("</think>")[-1].strip()
+    return response
+
+
+def main():
+    RSS_URL = 'https://papers.takara.ai/api/feed'
+    OUTPUT_FILE = 'papers_summary.md'
+    
+    try:
+        xml_content = fetch_rss(RSS_URL)
+        markdown = parse_rss_to_markdown(xml_content)
+        summary = summarize_with_groq(markdown)
+        
+        with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+            f.write(summary)
+        
+        print(f"Summarization successful! Output saved to {OUTPUT_FILE}")
+    
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+    
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/python/summary.go
+++ b/python/summary.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// RSS structure definitions
+type RSS struct {
+	XMLName xml.Name `xml:"rss"`
+	Channel Channel  `xml:"channel"`
+}
+
+type Channel struct {
+	Title         string `xml:"title"`
+	Description   string `xml:"description"`
+	LastBuildDate string `xml:"lastBuildDate"`
+	Items         []Item `xml:"item"`
+}
+
+type Item struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	Description string `xml:"description"`
+}
+
+// Groq API structures
+type GroqRequest struct {
+	Model               string    `json:"model"`
+	Messages            []Message `json:"messages"`
+	Temperature         float64   `json:"temperature"`
+	MaxCompletionTokens int       `json:"max_completion_tokens"`
+	TopP                float64   `json:"top_p"`
+	Stream              bool      `json:"stream"`
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type GroqResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index   int `json:"index"`
+		Message struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"message"`
+		LogProbs     interface{} `json:"logprobs"`
+		FinishReason string      `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		QueueTime       float64 `json:"queue_time"`
+		PromptTokens    int     `json:"prompt_tokens"`
+		PromptTime      float64 `json:"prompt_time"`
+		CompletionTokens int    `json:"completion_tokens"`
+		CompletionTime   float64 `json:"completion_time"`
+		TotalTokens      int    `json:"total_tokens"`
+		TotalTime        float64 `json:"total_time"`
+	} `json:"usage"`
+	SystemFingerprint string `json:"system_fingerprint"`
+	XGroq             struct {
+		ID string `json:"id"`
+	} `json:"x_groq"`
+}
+
+// fetchRSS fetches RSS feed content from a URL
+func fetchRSS(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// parseRSSToMarkdown parses RSS XML content and converts to markdown format
+func parseRSSToMarkdown(xmlContent string) (string, error) {
+	var rss RSS
+	err := xml.Unmarshal([]byte(xmlContent), &rss)
+	if err != nil {
+		return "", err
+	}
+
+	// Format date
+	var formattedDate string
+	parsedDate, err := time.Parse("Mon, 02 Jan 2006 15:04:05 -0700", rss.Channel.LastBuildDate)
+	if err != nil {
+		formattedDate = rss.Channel.LastBuildDate // Fallback to original format
+	} else {
+		formattedDate = parsedDate.Format("2006-01-02")
+	}
+
+	// Create markdown
+	var markdown strings.Builder
+
+	markdown.WriteString(fmt.Sprintf("# %s\n\n", rss.Channel.Title))
+	markdown.WriteString(fmt.Sprintf("*%s*\n\n", rss.Channel.Description))
+	markdown.WriteString(fmt.Sprintf("*Last updated: %s*\n\n", formattedDate))
+	markdown.WriteString("---\n\n")
+
+	// Process each item
+	for _, item := range rss.Channel.Items {
+		title := strings.ReplaceAll(item.Title, "\n", " ")
+		title = strings.TrimSpace(title)
+		
+		markdown.WriteString(fmt.Sprintf("## [%s](%s)\n\n", title, item.Link))
+		markdown.WriteString(fmt.Sprintf("%s\n\n", item.Description))
+		markdown.WriteString("---\n\n")
+	}
+
+	return markdown.String(), nil
+}
+
+// summarizeWithGroq summarizes the markdown content using Groq API
+func summarizeWithGroq(markdownContent, apiKey string) (string, error) {
+	groqURL := "https://api.groq.com/openai/v1/chat/completions"
+
+	prompt := `Create a brief morning briefing on these AI research papers, written in a conversational style for busy professionals. Focus on what's new and what it means for businesses and society.
+Format:
+1. Morning Headline (1 sentence)
+2. What's New (2-3 sentences, written like you're explaining it to a friend over coffee, with citations to papers as [Paper Name](link))
+ • Cover all papers in a natural, flowing narrative
+ • Group related papers together
+ • Include key metrics and outcomes
+ • Keep the tone light and engaging
+Keep it under 200 words. Focus on outcomes and implications, not technical details. Write like you're explaining it to a friend over coffee.
+Below are the paper abstracts and information in markdown format:
+` + markdownContent
+
+	request := GroqRequest{
+		Model: "deepseek-r1-distill-llama-70b",
+		Messages: []Message{
+			{
+				Role:    "user",
+				Content: prompt,
+			},
+		},
+		Temperature:         0.6,
+		MaxCompletionTokens: 4096,
+		TopP:                0.95,
+		Stream:              false,
+	}
+
+	requestBody, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", groqURL, bytes.NewBuffer(requestBody))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP error from Groq API: %d", resp.StatusCode)
+	}
+
+	var groqResp GroqResponse
+	if err := json.NewDecoder(resp.Body).Decode(&groqResp); err != nil {
+		return "", err
+	}
+
+	if len(groqResp.Choices) == 0 {
+		return "", fmt.Errorf("no response choices returned from Groq API")
+	}
+
+	response := groqResp.Choices[0].Message.Content
+
+	// Extract only the content after <think> tags if present
+	if strings.Contains(response, "<think>") {
+		parts := strings.Split(response, "</think>")
+		if len(parts) > 1 {
+			response = strings.TrimSpace(parts[len(parts)-1])
+		}
+	}
+
+	return response, nil
+}
+
+func main() {
+	rssURL := "https://papers.takara.ai/api/feed"
+	outputFile := "papers_summary.md"
+	apiKey := "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"
+
+	if apiKey == "" {
+		fmt.Println("Error: GROQ_API_KEY environment variable is not set")
+		os.Exit(1)
+	}
+
+	// Fetch RSS
+	xmlContent, err := fetchRSS(rssURL)
+	if err != nil {
+		fmt.Printf("Error fetching RSS: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse to markdown
+	markdown, err := parseRSSToMarkdown(xmlContent)
+	if err != nil {
+		fmt.Printf("Error parsing RSS to markdown: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Summarize with Groq
+	summary, err := summarizeWithGroq(markdown, apiKey)
+	if err != nil {
+		fmt.Printf("Error summarizing with Groq: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write to file
+	err = os.WriteFile(outputFile, []byte(summary), 0644)
+	if err != nil {
+		fmt.Printf("Error writing to file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Summarization successful! Output saved to %s\n", outputFile)
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
-  "builds": [{ "src": "api/*.go", "use": "@vercel/go" }],
+  "functions": {
+    "api/*.go": {
+      "maxDuration": 60
+    }
+  },
   "routes": [
     { "src": "/api$", "dest": "/api" },
     { "src": "/api/(.*)", "dest": "/api" }
@@ -9,10 +13,5 @@
       "path": "/api/update-cache",
       "schedule": "0 0 * * *"
     }
-  ],
-  "functions": {
-    "api/*.go": {
-      "maxDuration": 60
-    }
-  }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
-  "builds": [
-    { "src": "api/*.go", "use": "@vercel/go" }
-  ],
+  "builds": [{ "src": "api/*.go", "use": "@vercel/go" }],
   "routes": [
     { "src": "/api$", "dest": "/api" },
     { "src": "/api/(.*)", "dest": "/api" }
@@ -11,5 +9,10 @@
       "path": "/api/update-cache",
       "schedule": "0 0 * * *"
     }
-  ]
-} 
+  ],
+  "functions": {
+    "api/*.go": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
# Add AI Research Papers Summary Feed

## Overview
This PR adds a new `/api/summary` endpoint that generates a daily AI research papers summary in RSS format. The summary provides a concise, business-friendly overview of the latest papers from Hugging Face, written in a conversational style.

## Features
- New `/api/summary` endpoint that returns an RSS feed
- Daily AI research papers summary with morning headlines and key findings
- Business-friendly summaries written in a conversational style
- Proper RSS feed formatting with GUIDs and atom:link support
- Redis caching to minimize LLM API calls
- Automatic daily updates via cron job

## Technical Details
- Uses Hugging Face Router API for summarization
- Implements proper RSS 2.0 feed structure with:
  - Correct GUID format with `isPermaLink` attribute
  - `atom:link` with `rel="self"` for feed reader interoperability
  - CDATA-wrapped HTML content in descriptions
- Redis caching with 24-hour duration
- Automatic cache invalidation when feed content updates
- Comprehensive error handling and logging

## Example Response
```xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>宝の知識: Hugging Face 論文サマリー</title>
    <link>https://huggingface.co/papers</link>
    <description>最先端のAI論文の要約をお届けする、Takara.aiの厳選フィード</description>
    <lastBuildDate>Mon, 31 Mar 2025 21:27:27 +0000</lastBuildDate>
    <item>
      <title>AI Research Papers Summary for March 31, 2025</title>
      <link>https://huggingface.co/papers</link>
      <description><![CDATA[<div>
        <h2>Morning Headline</h2>
        <p>AI gets leaner, smarter, and more specialized...</p>
        <h2>What's New</h2>
        <p>Hot off the press: AdaptiVocab...</p>
      </div>]]></description>
      <pubDate>Mon, 31 Mar 2025 21:27:27 +0000</pubDate>
      <guid isPermaLink="false">summary-2025-03-31</guid>
    </item>
    <atom:link href="https://papers.takara.ai/api/summary" rel="self" type="application/rss+xml"/>
  </channel>
</rss>
```

## Testing
- [x] Test the `/api/summary` endpoint locally
- [x] Verify RSS feed validation
- [x] Check Redis caching behavior
- [ ] Test cache invalidation when feed updates
- [ ] Verify daily cron job updates

## Dependencies
- Requires `HF_API_KEY` environment variable for Hugging Face Router API
- Redis connection for caching (optional, falls back to direct generation)