### PR TITLE
Update Hugging Face Router API endpoint for Qwen2.5-72B-Instruct model

### DIFF
--- a/api/index.go
+++ b/api/index.go
@@ -507,7 +507,7 @@ func parseRSSToMarkdown(xmlContent string) (string, error) {
 // summarizeWithLLM summarizes the markdown content using Hugging Face Router API
 // It now accepts a context for cancellation and timeout, and uses an HTTP client with a timeout.
 func summarizeWithLLM(ctx context.Context, markdownContent string) (string, error) {
-	apiURL := "https://router.huggingface.co/sambanova/v1/chat/completions"
+	apiURL := "https://router.huggingface.co/hf-inference/models/Qwen/Qwen2.5-72B-Instruct/v1/chat/completions"
 	apiKey := os.Getenv("HF_API_KEY")
 	
 	if apiKey == "" {
@@ -536,7 +536,7 @@ Below are the paper abstracts and information in markdown format:
 ` + markdownContent
 
 	request := LLMRequest{
-		Model: "Qwen2.5-72B-Instruct",
+		Model: "Qwen/Qwen2.5-72B-Instruct",
 		Messages: []Message{
 			{
 				Role:    "user",


### PR DESCRIPTION
This PR addresses a critical API error affecting our summary generation service. The previous Sambanova-hosted endpoint for Qwen2.5-72B-Instruct has been deprecated, causing HTTP 410 errors in production.

Changes:
- Updated API endpoint to use the official Hugging Face inference endpoint
- Updated model name format to match new API requirements
- Maintained existing functionality and request structure

Previous endpoint:
https://router.huggingface.co/sambanova/v1/chat/completions

New endpoint:
https://router.huggingface.co/hf-inference/models/Qwen/Qwen2.5-72B-Instruct/v1/chat/completions

This change ensures continued operation of our summary generation service while maintaining the same model and capabilities.

Testing:
- Verified API connectivity with new endpoint
- Confirmed summary generation works as expected
- Validated response format consistency