### PR TITLE
Refactor: Replace Redis Cache with Vercel Edge Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ A serverless RSS feed for papers published on Hugging Face's [papers page](https
 ## Features
 
 - Serverless deployment on Vercel
-- Redis caching to minimize scraping
-- Daily automatic updates via cron job
+- Vercel Edge Caching to minimize scraping and provide low-latency responses globally
+- Daily automatic cache refresh (target: 6 AM UTC)
 - Clean RSS feed with paper titles, links and abstracts
 - LLM-powered summary feed of the latest papers
+- LLM-powered podcast feed (conversation + audio) of the latest papers
 - Health check and status endpoints
 - CORS enabled for cross-origin requests
 
@@ -17,8 +18,9 @@ A serverless RSS feed for papers published on Hugging Face's [papers page](https
 ### Prerequisites
 
 - A [Vercel](https://vercel.com) account
-- A Redis database (e.g. [Upstash](https://upstash.com))
-- Go 1.x installed locally for development
+- Go 1.22+ installed locally for development
+- A Hugging Face API key (for LLM summaries and podcast generation)
+- A DeepInfra API key (for podcast audio generation)
 
 ### Deploy to Vercel
 
@@ -29,42 +31,55 @@ A serverless RSS feed for papers published on Hugging Face's [papers page](https
 3. Set up the following environment variables in your Vercel project settings:
 
 ```env
-KV_URL=your_redis_url
-KV_REST_API_TOKEN=your_redis_write_token
-KV_REST_API_READ_ONLY_TOKEN=your_redis_read_token
-KV_REST_API_URL=your_redis_rest_api_url
+# Required for LLM Summaries / Podcast Generation
 HF_API_KEY=your_hugging_face_api_key
-UPDATE_KEY=your_secret_key_here
+
+# Required for Podcast Audio Generation
+DEEPINFRA_API_KEY=your_deepinfra_api_key
+
+# Optional: Secret key for potentially adding manual cache purge in the future (not currently implemented)
+# UPDATE_KEY=your_secret_key_here
 ```
 
-4. Deploy! Vercel will automatically build and deploy your RSS feed service
+4. Deploy! Vercel will automatically build and deploy your RSS feed service.
 
 The feed will be available at: `https://your-project.vercel.app/api/feed`
+The summary feed will be available at: `https://your-project.vercel.app/api/summary`
+The podcast conversation (JSON) will be available at: `https://your-project.vercel.app/api/conversation`
+The podcast audio (MP3) will be available at: `https://your-project.vercel.app/api/podcast`
 
 ### Local Development
 
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/yourusername/daily-papers.git
-cd daily-papers
+git clone https://github.com/yourusername/hf-daily-papers-feeds.git # Make sure to use your repo name
+cd hf-daily-papers-feeds
 ```
 
-2. Create a `.env` file in the root directory with your Redis and Hugging Face credentials:
+2. Create a `.env` file in the root directory with your Hugging Face and DeepInfra API keys:
 
 ```env
-KV_URL=your_redis_url
-KV_REST_API_TOKEN=your_redis_write_token
-KV_REST_API_READ_ONLY_TOKEN=your_redis_read_token
-KV_REST_API_URL=your_redis_rest_api_url
+# Required for LLM Summaries / Podcast Generation
 HF_API_KEY=your_hugging_face_api_key
-UPDATE_KEY=your_secret_key_here
+
+# Required for Podcast Audio Generation
+DEEPINFRA_API_KEY=your_deepinfra_api_key
+
+# Optional: Secret key for potentially adding manual cache purge in the future (not currently implemented)
+# UPDATE_KEY=your_secret_key_here
 ```
 
 3. Run the development server:
 
 ```bash
 vercel dev
+```
+
+Or run the Go server directly (listens on port 3000 by default):
+
+```bash
+go run main.go
 ```
 
 The local server will be available at `http://localhost:3000`
@@ -74,34 +89,16 @@ The local server will be available at `http://localhost:3000`
 - `/api` - Health check and status
 - `/api/feed` - RSS feed of papers
 - `/api/summary` - RSS feed summarizing the papers using an LLM
-- `/api/update-cache` - Manually trigger feed update (requires authentication)
+- `/api/conversation` - JSON feed containing the generated podcast conversation
+- `/api/podcast` - MP3 audio feed of the generated podcast
 
-## Manual Cache Updates
+## Caching
 
-To enable secure manual cache updates, you need to set an `UPDATE_KEY` environment variable:
+This service leverages Vercel's Edge Caching. Responses are cached globally with a `Cache-Control` header set to expire around 6 AM UTC daily. This means fresh content is generated approximately once per day.
 
-1. Add to your Vercel environment variables:
-
-```env
-UPDATE_KEY=your_secret_key_here
-```
-
-2. To manually trigger a cache update, use the following curl command:
-
-```bash
-curl -X GET \
-  https://your-project.vercel.app/api/update-cache \
-  -H 'X-Update-Key: your_secret_key_here'
-```
-
-Successful response:
-
-```json
-{
-  "status": "Cache updated successfully",
-  "timestamp": "2024-03-20T15:30:45Z"
-}
-```
+- **Cache Duration:** Calculated dynamically to expire at the next 6:00 AM UTC.
+- **Cache Control:** `public, max-age=0, s-maxage=<seconds_until_6am_utc>`
+- **Invalidation:** Cache automatically expires based on `s-maxage` or when a new deployment occurs.
 
 ## Example Response
 
@@ -110,10 +107,14 @@ Health check (`/api`):
 ```json
 {
   "status": "ok",
-  "endpoints": ["/api/feed", "/api/summary"],
-  "cache_status": true,
-  "timestamp": "2024-03-20T15:30:45Z",
-  "version": "1.0.0"
+  "endpoints": [
+    "/api/feed",
+    "/api/summary",
+    "/api/conversation",
+    "/api/podcast"
+  ],
+  "timestamp": "2024-07-29T10:00:00Z",
+  "version": "1.1.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ The local server will be available at `http://localhost:3000`
 - `/api` - Health check and status
 - `/api/feed` - RSS feed of papers
 - `/api/summary` - RSS feed summarizing the papers using an LLM
-- `/api/conversation` - JSON feed containing the generated podcast conversation
-- `/api/podcast` - MP3 audio feed of the generated podcast
 
 ## Caching
 
@@ -100,6 +98,28 @@ This service leverages Vercel's Edge Caching. Responses are cached globally with
 - **Cache Control:** `public, max-age=0, s-maxage=<seconds_until_6am_utc>`
 - **Invalidation:** Cache automatically expires based on `s-maxage` or when a new deployment occurs.
 
+## Performance Comparison
+
+### Sequential `curl` Benchmark
+
+A basic sequential benchmark using `curl` from a single location provides a rough latency comparison.
+
+| Version        | Request # | Time (seconds)  | Notes                |
+| -------------- | --------- | --------------- | -------------------- |
+| Redis (Legacy) | 1         | 0.022432        | @ `papers.takara.ai` |
+| Redis (Legacy) | 2         | 0.020673        |                      |
+| Redis (Legacy) | 3         | 0.021362        |                      |
+| Redis (Legacy) | 4         | 0.022083        |                      |
+| Redis (Legacy) | 5         | 0.016121        |                      |
+| Redis (Legacy) | 6         | 0.018705        |                      |
+| Redis (Legacy) | 7         | 0.017078        |                      |
+| Redis (Legacy) | 8         | 0.018801        |                      |
+| Redis (Legacy) | 9         | 0.018036        |                      |
+| Redis (Legacy) | 10        | 0.026124        |                      |
+| Vercel Edge    | _1-10_    | _(To be added)_ | _(New version)_      |
+
+_Note: This sequential `curl` test does not represent performance under concurrent load. Vercel Edge Caching is expected to offer better global performance._
+
 ## Example Response
 
 Health check (`/api`):
@@ -107,12 +127,7 @@ Health check (`/api`):
 ```json
 {
   "status": "ok",
-  "endpoints": [
-    "/api/feed",
-    "/api/summary",
-    "/api/conversation",
-    "/api/podcast"
-  ],
+  "endpoints": ["/api/feed", "/api/summary"],
   "timestamp": "2024-07-29T10:00:00Z",
   "version": "1.1.0"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,10 @@
 module hf-papers-rss
 
-go 1.23
+go 1.22.2
 
 toolchain go1.23.4
 
 require (
-	github.com/redis/go-redis/v9 v9.7.0
-	golang.org/x/net v0.32.0
-)
-
-require (
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/joho/godotenv v1.5.1
+	golang.org/x/net v0.26.0
 )


### PR DESCRIPTION
**Description:**

This pull request replaces the Upstash Redis caching layer with Vercel's built-in Edge Caching mechanism. The goal is to simplify the application architecture, reduce external dependencies and associated costs, and leverage the native caching capabilities of the Vercel platform.

**Key Changes:**

*   **Removed Redis Dependency:** Eliminated all code related to Redis client initialization, connection management, `GET`/`SET` operations, and associated environment variables (`KV_*`). The `go-redis` library has been removed from `go.mod` and `go.sum`.
*   **Implemented Vercel Edge Caching:**
    *   Added `Cache-Control: public, max-age=0, s-maxage=<seconds>` headers to the `/api/feed` and `/api/summary` endpoint responses.
    *   The `s-maxage` value is dynamically calculated to expire the cache daily at approximately 6:00 AM UTC, ensuring fresh content is generated roughly once per day.
*   **Simplified API Logic:** Endpoint handlers now directly call the data generation functions (`generateFeed`, `generateSummary`) when a cache miss occurs on the Vercel Edge Network, rather than interacting with an intermediate Redis cache.
*   **Removed Manual Cache Update:** The `/api/update-cache` endpoint and its associated `UPDATE_KEY` logic have been removed, as cache invalidation is now handled by `s-maxage` expiration or new deployments.
*   **Temporarily Disabled Endpoints:** Commented out the `/api/conversation` and `/api/podcast` routes and associated logic as they are not yet production-ready. These endpoints now return 404.
*   **Updated Documentation:** `README.md` has been updated to reflect the removal of Redis, the new Vercel Edge Caching strategy, updated environment variable requirements, and basic performance benchmarks from the previous version.

**Motivation:**

*   Simplify infrastructure and reduce operational overhead.
*   Potentially lower costs by removing the need for a managed Redis instance.
*   Leverage Vercel's Edge Network for potentially improved global latency.
*   Align caching strategy with Vercel deployment best practices.

**Testing:**

*   **Local:** Verified using `go run main.go` and `curl -I` that the `Cache-Control` header with dynamic `s-maxage` is correctly set on `/api/feed` and `/api/summary` responses. Build successful (`go build ./...`).
*   **Deployment:** Manual testing on a Vercel preview deployment confirmed the headers are present. Further testing is needed to confirm public accessibility after addressing potential Vercel authentication settings and to observe cache HIT/MISS behavior over time.

**Potential Issues:**

*   Ensure Vercel deployment protection/authentication is configured correctly to allow public access to the intended API endpoints (`/api/feed`, `/api/summary`). The initial test on a preview link returned 401.

**Next Steps:**

*   Merge into `main`.
*   Deploy to production Vercel environment.
*   Monitor performance and caching behavior.
*   (Optional) Re-enable `/api/conversation` and `/api/podcast` when ready.